### PR TITLE
De-register with content type header

### DIFF
--- a/eurekaclient.go
+++ b/eurekaclient.go
@@ -162,6 +162,7 @@ func deregister(appName string) {
 	// Deregister
 	deregisterAction := HttpAction{
 		Url:    discoveryServerUrl + "/eureka/apps/" + appName + "/" + getLocalIP(),
+		ContentType: "application/json;charset=UTF-8",
 		Method: "DELETE",
 	}
 	doHttpRequest(deregisterAction)

--- a/eurekaclient.go
+++ b/eurekaclient.go
@@ -46,12 +46,19 @@ var regTpl = `{
     "ipAddr":"${ipAddress}",
     "vipAddress":"${appName}",
     "status":"UP",
-    "port":"${port}",
-    "securePort" : "${securePort}",
+    "port": {
+      "$":${port},
+      "@enabled": true
+    },
+    "securePort": {
+      "$":${securePort},
+      "@enabled": true
+    },
     "homePageUrl" : "http://${ipAddress}:${port}/",
     "statusPageUrl": "http://${ipAddress}:${port}/info",
     "healthCheckUrl": "http://${ipAddress}:${port}/health",
     "dataCenterInfo" : {
+      "@class":"com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo",
       "name": "MyOwn"
     },
     "metadata": {


### PR DESCRIPTION
The DELETE request was failing with a 400. The content types supplied must be application/xml or application/json. Used JSON to be consistent with other requests.